### PR TITLE
Remove subnav

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,12 @@
 This repository contains multiple packages that all implement
 a part of EventSauce's storage related interfaces.
 
-- [Message Repositories](#message-repositories)
-- [Message Outboxes](#message-outboxes)
-
 ## Message Repositories
 
 Message repositories are used to store messages in for
 aggregate root reconstitution.
 
 [View the docs](#pending)
-
 
 ## Message Outboxes
 


### PR DESCRIPTION
Bit redundant with the readme being this small and there's navigation on the GitHub Readme in the top left corner anyway.