### PR TITLE
Fix binary UUID usage

### DIFF
--- a/src/DoctrineMessageRepository/DefaultDoctrineMessageRepositoryTest.php
+++ b/src/DoctrineMessageRepository/DefaultDoctrineMessageRepositoryTest.php
@@ -18,6 +18,7 @@ class DefaultDoctrineMessageRepositoryTest extends DoctrineMessageRepositoryTest
             serializer: new ConstructingMessageSerializer(),
             tableSchema: new DefaultTableSchema(),
             aggregateRootIdEncoder: new BinaryUuidIdEncoder(),
+            eventIdEncoder: new BinaryUuidIdEncoder(),
         );
     }
 }

--- a/src/DoctrineMessageRepository/DoctrineMessageRepositoryTestCase.php
+++ b/src/DoctrineMessageRepository/DoctrineMessageRepositoryTestCase.php
@@ -32,6 +32,28 @@ abstract class DoctrineMessageRepositoryTestCase extends MessageRepositoryTestCa
         $this->truncateTable();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if (str_contains($this->formatDsn(), 'pgsql')) {
+            // can only check this for mysql
+            return;
+        }
+
+        $warning = $this->connection->executeQuery('SHOW WARNINGS')->fetchNumeric();
+        if ($warning !== false && count($warning) > 0) {
+            if (str_contains($warning[2], 'Base table or view not found') || str_contains($warning[2], "doesn't exist")) {
+                // shortcut for tests
+                return;
+            }
+            self::fail(sprintf(
+                'Warnings issued durings tests, these can potentially result in data loss: [%d] %s',
+                $warning[1],
+                $warning[2],
+            ));
+        }
+    }
+
     protected function formatDsn(): string
     {
         $host = getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1';

--- a/src/DoctrineMessageRepository/DoctrineUuidV4MessageRepository.php
+++ b/src/DoctrineMessageRepository/DoctrineUuidV4MessageRepository.php
@@ -3,6 +3,7 @@
 namespace EventSauce\MessageRepository\DoctrineMessageRepository;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Header;
@@ -74,9 +75,11 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
             $payload = $this->serializer->serializeMessage($message);
             $payload['headers'][Header::EVENT_ID] ??= Uuid::uuid4()->toString();
 
+            $eventIdIndex = $this->indexParameter('event_id', $index);
+            $aggregateRootIdIndex = $this->indexParameter('aggregate_root_id', $index);
             $messageParameters = [
-                $this->indexParameter('event_id', $index) => $this->uuidEncoder->encodeString($payload['headers'][Header::EVENT_ID]),
-                $this->indexParameter('aggregate_root_id', $index) => $this->uuidEncoder->encodeString($payload['headers'][Header::AGGREGATE_ROOT_ID]),
+                $eventIdIndex => $this->uuidEncoder->encodeString($payload['headers'][Header::EVENT_ID]),
+                $aggregateRootIdIndex => $this->uuidEncoder->encodeString($payload['headers'][Header::AGGREGATE_ROOT_ID]),
                 $this->indexParameter('version', $index) => $payload['headers'][Header::AGGREGATE_ROOT_VERSION] ?? 0,
                 $this->indexParameter('payload', $index) => json_encode($payload, $this->jsonEncodeOptions),
             ];
@@ -99,8 +102,14 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
             implode("),\n(", $insertValues),
         );
 
+        $types = [];
+        if ($this->uuidEncoder instanceof BinaryUuidEncoder) {
+            $types[$eventIdIndex] = ParameterType::BINARY;
+            $types[$aggregateRootIdIndex] = ParameterType::BINARY;
+        }
+
         try {
-            $this->connection->executeStatement($insertQuery, $insertParameters);
+            $this->connection->executeStatement($insertQuery, $insertParameters, $types);
         } catch (Throwable $exception) {
             throw UnableToPersistMessages::dueTo('', $exception);
         }
@@ -120,7 +129,7 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
     {
         $builder = $this->createQueryBuilder();
         $builder->where(sprintf('%s = :aggregate_root_id', $this->tableSchema->aggregateRootIdColumn()));
-        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()));
+        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()), $this->uuidEncoder instanceof BinaryUuidEncoder ? ParameterType::BINARY : ParameterType::STRING);
 
         try {
             return $this->yieldMessagesFromPayloads($builder->executeQuery()->iterateColumn());
@@ -137,7 +146,7 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
         $builder = $this->createQueryBuilder();
         $builder->where(sprintf('%s = :aggregate_root_id', $this->tableSchema->aggregateRootIdColumn()));
         $builder->andWhere(sprintf('%s > :version', $this->tableSchema->versionColumn()));
-        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()));
+        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()), $this->uuidEncoder instanceof BinaryUuidEncoder ? ParameterType::BINARY : ParameterType::STRING);
         $builder->setParameter('version', $aggregateRootVersion);
 
         try {

--- a/src/DoctrineV2MessageRepository/DefaultDoctrineMessageRepositoryTest.php
+++ b/src/DoctrineV2MessageRepository/DefaultDoctrineMessageRepositoryTest.php
@@ -6,7 +6,6 @@ use EventSauce\EventSourcing\MessageRepository;
 use EventSauce\EventSourcing\Serialization\ConstructingMessageSerializer;
 use EventSauce\MessageRepository\DoctrineV2MessageRepository\DoctrineMessageRepositoryTestCase;
 use EventSauce\MessageRepository\TableSchema\DefaultTableSchema;
-use EventSauce\UuidEncoding\BinaryUuidEncoder;
 
 /**
  * @group doctrine2

--- a/src/DoctrineV2MessageRepository/DoctrineMessageRepository.php
+++ b/src/DoctrineV2MessageRepository/DoctrineMessageRepository.php
@@ -132,7 +132,7 @@ class DoctrineMessageRepository implements MessageRepository
     {
         $builder = $this->createQueryBuilder();
         $builder->where(sprintf('%s = :aggregate_root_id', $this->tableSchema->aggregateRootIdColumn()));
-        $builder->setParameter('aggregate_root_id', $this->aggregateRootIdEncoder->encodeId($id));
+        $builder->setParameter('aggregate_root_id', $this->aggregateRootIdEncoder->encodeId($id), $this->aggregateRootIdEncoder instanceof BinaryUuidIdEncoder ? ParameterType::BINARY : ParameterType::STRING);
 
         try {
             /** @var ResultStatement $resultStatement */
@@ -152,7 +152,7 @@ class DoctrineMessageRepository implements MessageRepository
         $builder = $this->createQueryBuilder();
         $builder->where(sprintf('%s = :aggregate_root_id', $this->tableSchema->aggregateRootIdColumn()));
         $builder->andWhere(sprintf('%s > :version', $this->tableSchema->versionColumn()));
-        $builder->setParameter('aggregate_root_id', $this->aggregateRootIdEncoder->encodeId($id));
+        $builder->setParameter('aggregate_root_id', $this->aggregateRootIdEncoder->encodeId($id), $this->aggregateRootIdEncoder instanceof BinaryUuidIdEncoder ? ParameterType::BINARY : ParameterType::STRING);
         $builder->setParameter('version', $aggregateRootVersion);
 
         try {

--- a/src/DoctrineV2MessageRepository/DoctrineMessageRepositoryTestCase.php
+++ b/src/DoctrineV2MessageRepository/DoctrineMessageRepositoryTestCase.php
@@ -39,7 +39,7 @@ abstract class DoctrineMessageRepositoryTestCase extends MessageRepositoryTestCa
         }
 
         $warning = $this->connection->executeQuery('SHOW WARNINGS')->fetchNumeric();
-        if (count($warning) > 0) {
+        if ($warning !== false && count($warning) > 0) {
             if (str_contains($warning[2], 'Base table or view not found') || str_contains($warning[2], "doesn't exist")) {
                 // shortcut for tests
                 return;

--- a/src/DoctrineV2MessageRepository/DoctrineMessageRepositoryTestCase.php
+++ b/src/DoctrineV2MessageRepository/DoctrineMessageRepositoryTestCase.php
@@ -30,6 +30,28 @@ abstract class DoctrineMessageRepositoryTestCase extends MessageRepositoryTestCa
         $this->connection->executeQuery('TRUNCATE TABLE ' . $this->tableName);
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if (str_contains($this->formatDsn(), 'pgsql')) {
+            // can only check this for mysql
+            return;
+        }
+
+        $warning = $this->connection->executeQuery('SHOW WARNINGS')->fetchNumeric();
+        if (count($warning) > 0) {
+            if (str_contains($warning[2], 'Base table or view not found') || str_contains($warning[2], "doesn't exist")) {
+                // shortcut for tests
+                return;
+            }
+            self::fail(sprintf(
+                'Warnings issued durings tests, these can potentially result in data loss: [%d] %s',
+                $warning[1],
+                $warning[2],
+            ));
+        }
+    }
+
     protected function aggregateRootId(): AggregateRootId
     {
         return DummyAggregateRootId::generate();

--- a/src/DoctrineV2MessageRepository/DoctrineUuidV4MessageRepository.php
+++ b/src/DoctrineV2MessageRepository/DoctrineUuidV4MessageRepository.php
@@ -5,6 +5,7 @@ namespace EventSauce\MessageRepository\DoctrineV2MessageRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\ForwardCompatibility\Result;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Header;
@@ -78,9 +79,11 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
             $payload = $this->serializer->serializeMessage($message);
             $payload['headers'][Header::EVENT_ID] ??= Uuid::uuid4()->toString();
 
+            $eventIdIndex = $this->indexParameter('event_id', $index);
+            $aggregateRootIdIndex = $this->indexParameter('aggregate_root_id', $index);
             $messageParameters = [
-                $this->indexParameter('event_id', $index) => $this->uuidEncoder->encodeString($payload['headers'][Header::EVENT_ID]),
-                $this->indexParameter('aggregate_root_id', $index) => $this->uuidEncoder->encodeString($payload['headers'][Header::AGGREGATE_ROOT_ID]),
+                $eventIdIndex => $this->uuidEncoder->encodeString($payload['headers'][Header::EVENT_ID]),
+                $aggregateRootIdIndex => $this->uuidEncoder->encodeString($payload['headers'][Header::AGGREGATE_ROOT_ID]),
                 $this->indexParameter('version', $index) => $payload['headers'][Header::AGGREGATE_ROOT_VERSION] ?? 0,
                 $this->indexParameter('payload', $index) => json_encode($payload, $this->jsonEncodeOptions),
             ];
@@ -103,8 +106,14 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
             implode("),\n(", $insertValues),
         );
 
+        $types = [];
+        if ($this->uuidEncoder instanceof BinaryUuidEncoder) {
+            $types[$eventIdIndex] = ParameterType::BINARY;
+            $types[$aggregateRootIdIndex] = ParameterType::BINARY;
+        }
+
         try {
-            $this->connection->executeStatement($insertQuery, $insertParameters);
+            $this->connection->executeStatement($insertQuery, $insertParameters, $types);
         } catch (Throwable $exception) {
             throw UnableToPersistMessages::dueTo('', $exception);
         }
@@ -124,7 +133,7 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
     {
         $builder = $this->createQueryBuilder();
         $builder->where(sprintf('%s = :aggregate_root_id', $this->tableSchema->aggregateRootIdColumn()));
-        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()));
+        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()), $this->uuidEncoder instanceof BinaryUuidEncoder ? ParameterType::BINARY : ParameterType::STRING);
 
         try {
             /** @var ResultStatement $resultStatement */
@@ -144,7 +153,7 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
         $builder = $this->createQueryBuilder();
         $builder->where(sprintf('%s = :aggregate_root_id', $this->tableSchema->aggregateRootIdColumn()));
         $builder->andWhere(sprintf('%s > :version', $this->tableSchema->versionColumn()));
-        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()));
+        $builder->setParameter('aggregate_root_id', $this->uuidEncoder->encodeString($id->toString()), $this->uuidEncoder instanceof BinaryUuidEncoder ? ParameterType::BINARY : ParameterType::STRING);
         $builder->setParameter('version', $aggregateRootVersion);
 
         try {


### PR DESCRIPTION
When using binary values in queries, MySQL needs to specifically be told it's a binary value. With DBAL that's done with `ParameterType::BINARY` which gets translated to `PDO::PARAM_LOB`.
In most cases with uuids it won't directly cause issues, but MySQL still complains about it. 
And like with any character encoding issues, it's better to get ahead of it instead of trying to fix it after the fact.

Example of a failure:
```
1) EventSauce\MessageRepository\DoctrineMessageRepository\DefaultDoctrineUuidV4MessageRepositoryTest::inserting_and_retrieving_messages
Warnings issued durings tests, these can potentially result in data loss: [1300] Invalid utf8mb4 character string: '987879'
```

Sidenote: this didn't even worked properly with PDO and emulated prepared statements (which is the default) until it got fixed last year: https://github.com/php/php-src/pull/15949