### PR TITLE
Pass uuid as binary

### DIFF
--- a/src/DoctrineMessageRepository/DefaultDoctrineMessageRepositoryTest.php
+++ b/src/DoctrineMessageRepository/DefaultDoctrineMessageRepositoryTest.php
@@ -5,9 +5,12 @@ namespace EventSauce\MessageRepository\DoctrineMessageRepository;
 use EventSauce\IdEncoding\BinaryUuidIdEncoder;
 use EventSauce\EventSourcing\Serialization\ConstructingMessageSerializer;
 use EventSauce\MessageRepository\TableSchema\DefaultTableSchema;
+use EventSauce\MessageRepository\TestTooling\BinaryUuidTestTrait;
 
 class DefaultDoctrineMessageRepositoryTest extends DoctrineMessageRepositoryTestCase
 {
+    use BinaryUuidTestTrait;
+
     protected string $tableName = 'domain_messages_uuid';
 
     protected function messageRepository(): DoctrineMessageRepository

--- a/src/DoctrineMessageRepository/DefaultDoctrineUuidV4MessageRepositoryTest.php
+++ b/src/DoctrineMessageRepository/DefaultDoctrineUuidV4MessageRepositoryTest.php
@@ -4,10 +4,13 @@ namespace EventSauce\MessageRepository\DoctrineMessageRepository;
 
 use EventSauce\EventSourcing\Serialization\ConstructingMessageSerializer;
 use EventSauce\MessageRepository\TableSchema\DefaultTableSchema;
+use EventSauce\MessageRepository\TestTooling\BinaryUuidTestTrait;
 use EventSauce\UuidEncoding\BinaryUuidEncoder;
 
 class DefaultDoctrineUuidV4MessageRepositoryTest extends DoctrineMessageRepositoryTestCase
 {
+    use BinaryUuidTestTrait;
+
     protected string $tableName = 'domain_messages_uuid';
 
     protected function messageRepository(): DoctrineUuidV4MessageRepository

--- a/src/MessageRepositoryTestTooling/BinaryUuidTestTrait.php
+++ b/src/MessageRepositoryTestTooling/BinaryUuidTestTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\MessageRepository\TestTooling;
+
+trait BinaryUuidTestTrait
+{
+    /**
+     * @test
+     */
+    public function it_uses_correct_parameter_types_for_binary_fields(): void
+    {
+        if (version_compare(PHP_VERSION, '8.4', '<')) {
+            self::markTestSkipped('PHP version needs to be >=8.4 to have PDO use binary hints');
+        }
+
+        $repository = $this->messageRepository();
+        $message = $this->createMessage('payload');
+
+        $repository->persist($message);
+        $this->assertWarnings('persist()');
+
+        $repository->retrieveAll($message->aggregateRootId());
+        $this->assertWarnings('retrieveAll()');
+
+        $repository->retrieveAllAfterVersion($message->aggregateRootId(), 1);
+        $this->assertWarnings('retrieveAllAfterVersion()');
+    }
+
+    private function assertWarnings(string $scenario): void
+    {
+        $warnings = $this->connection->executeQuery('SHOW WARNINGS')->fetchAllAssociative();
+        self::assertSame([], $warnings, 'Binary uuids were not properly passed during ' . $scenario);
+    }
+}


### PR DESCRIPTION
Attempt two for #35 

I did change the approach a bit, as it didn't feel good to keep it in `tearDown`, as it's very specific when it can run.

It now runs for MySQL only on PHP8.4+ 
I realized that it doesn't make sense to backport it to DoctrineV2, as that doesn't run on PHP8 anyway.