### PR TITLE
Ensure outbox stores message with same headers as regular repository

### DIFF
--- a/src/DoctrineOutbox/DoctrineTransactionalMessageRepository.php
+++ b/src/DoctrineOutbox/DoctrineTransactionalMessageRepository.php
@@ -4,12 +4,14 @@ namespace EventSauce\MessageOutbox\DoctrineOutbox;
 
 use Doctrine\DBAL\Connection;
 use EventSauce\EventSourcing\AggregateRootId;
+use EventSauce\EventSourcing\Header;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageRepository;
 use EventSauce\EventSourcing\PaginationCursor;
 use EventSauce\EventSourcing\UnableToPersistMessages;
 use EventSauce\MessageOutbox\OutboxRepository;
 use Generator;
+use Ramsey\Uuid\Uuid;
 use Throwable;
 
 class DoctrineTransactionalMessageRepository implements MessageRepository
@@ -23,6 +25,12 @@ class DoctrineTransactionalMessageRepository implements MessageRepository
     public function persist(Message ...$messages): void
     {
         try {
+            $messages = array_map(static function (Message $message) {
+                return $message->header(Header::EVENT_ID) === null
+                    ? $message->withHeader(Header::EVENT_ID, Uuid::uuid4()->toString())
+                    : $message;
+            }, $messages);
+
             $this->connection->beginTransaction();
 
             try {


### PR DESCRIPTION
Alternative to https://github.com/EventSaucePHP/EventSauce/pull/247

Currently when a message is persisted, the event ID is not set until the very last moment (when the message is inserted into the database). This causes outbox repositories and message dispatchers to receive message instances that do not have this header set.

This PR changes the transactional message repositories to set the event ID at the start of the transaction, only if the event ID is not already set. This makes it so the message and outbox repository both receive the same headers. The limitation of this approach (as opposed to https://github.com/EventSaucePHP/EventSauce/pull/247) is that when using an aggregate root repository, the message dispatcher will still receive stale instances. A workaround for that issue could be to simply use a MessageDecorator instead of relying on the message repositories.