### PR TITLE
Make sure the parameter type is added for each indexed parameter

### DIFF
--- a/src/DoctrineMessageRepository/DoctrineMessageRepository.php
+++ b/src/DoctrineMessageRepository/DoctrineMessageRepository.php
@@ -74,6 +74,7 @@ class DoctrineMessageRepository implements MessageRepository
 
         $insertValues = [];
         $insertParameters = [];
+        $types = [];
 
         foreach ($messages as $index => $message) {
             $payload = $this->serializer->serializeMessage($message);
@@ -92,6 +93,13 @@ class DoctrineMessageRepository implements MessageRepository
                 $messageParameters[$this->indexParameter($column, $index)] = $payload['headers'][$header];
             }
 
+            if ($this->binaryEventId) {
+                $types[$eventIdIndex] = ParameterType::BINARY;
+            }
+            if ($this->binaryAggregateRootId) {
+                $types[$aggregateRootIdIndex] = ParameterType::BINARY;
+            }
+
             // Creates a values line like: (:event_id_1, :aggregate_root_id_1, ...)
             $insertValues[] = implode(', ', $this->formatNamedParameters(array_keys($messageParameters)));
 
@@ -105,14 +113,6 @@ class DoctrineMessageRepository implements MessageRepository
             implode(', ', $insertColumns),
             implode("),\n(", $insertValues),
         );
-
-        $types = [];
-        if ($this->binaryEventId) {
-            $types[$eventIdIndex] = ParameterType::BINARY;
-        }
-        if ($this->binaryAggregateRootId) {
-            $types[$aggregateRootIdIndex] = ParameterType::BINARY;
-        }
 
         try {
             $this->connection->executeStatement($insertQuery, $insertParameters, $types);

--- a/src/DoctrineMessageRepository/DoctrineUuidV4MessageRepository.php
+++ b/src/DoctrineMessageRepository/DoctrineUuidV4MessageRepository.php
@@ -70,6 +70,8 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
 
         $insertValues = [];
         $insertParameters = [];
+        $types = [];
+        $isBinaryId = $this->uuidEncoder instanceof BinaryUuidEncoder;
 
         foreach ($messages as $index => $message) {
             $payload = $this->serializer->serializeMessage($message);
@@ -88,6 +90,11 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
                 $messageParameters[$this->indexParameter($column, $index)] = $payload['headers'][$header];
             }
 
+            if ($isBinaryId) {
+                $types[$eventIdIndex] = ParameterType::BINARY;
+                $types[$aggregateRootIdIndex] = ParameterType::BINARY;
+            }
+
             // Creates a values line like: (:event_id_1, :aggregate_root_id_1, ...)
             $insertValues[] = implode(', ', $this->formatNamedParameters(array_keys($messageParameters)));
 
@@ -101,14 +108,6 @@ class DoctrineUuidV4MessageRepository implements MessageRepository
             implode(', ', $insertColumns),
             implode("),\n(", $insertValues),
         );
-
-        $types = [];
-        if ($this->uuidEncoder instanceof BinaryUuidEncoder) {
-            $types = [
-                $eventIdIndex => ParameterType::BINARY,
-                $aggregateRootIdIndex => ParameterType::BINARY,
-            ];
-        }
 
         try {
             $this->connection->executeStatement($insertQuery, $insertParameters, $types);

--- a/src/MessageRepositoryTestTooling/BinaryUuidTestTrait.php
+++ b/src/MessageRepositoryTestTooling/BinaryUuidTestTrait.php
@@ -16,15 +16,16 @@ trait BinaryUuidTestTrait
         }
 
         $repository = $this->messageRepository();
-        $message = $this->createMessage('payload');
+        $message1 = $this->createMessage('payload1');
+        $message2 = $this->createMessage('payload2');
 
-        $repository->persist($message);
+        $repository->persist($message1, $message2);
         $this->assertWarnings('persist()');
 
-        $repository->retrieveAll($message->aggregateRootId());
+        $repository->retrieveAll($message1->aggregateRootId());
         $this->assertWarnings('retrieveAll()');
 
-        $repository->retrieveAllAfterVersion($message->aggregateRootId(), 1);
+        $repository->retrieveAllAfterVersion($message1->aggregateRootId(), 1);
         $this->assertWarnings('retrieveAllAfterVersion()');
     }
 


### PR DESCRIPTION
Hey Frank, found a small issue when inserting binary values in the message repository. The parameter type was only added once, at the end after the parameter loop. This should fix this (discussed with @wjzijderveld).